### PR TITLE
Scaffold agent-space package

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+OPENAI_API_KEY=your-openai-key
+ANTHROPIC_API_KEY=your-anthropic-key
+GEMINI_API_KEY=your-gemini-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.pyc
+.env
+*.egg-info/
+build/
+dist/
+.pytest_cache/
+.mypy_cache/
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## 0.1.0 - 2024-01-01
+- Initial scaffolding.
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2024 Agent Space
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+.PHONY: setup format lint type test docs
+
+setup:
+pip install -e .[all]
+
+format:
+black src tests
+
+lint:
+ruff check src tests
+
+type:
+mypy src
+
+test:
+pytest
+
+docs:
+mkdocs build
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # agent-space
+
+Agent Space is a batteries-included agent toolkit built on top of AG2.
+
+## Installation
+
+```bash
+pip install agent-space
+```
+

--- a/docs/api/reference.md
+++ b/docs/api/reference.md
@@ -1,0 +1,3 @@
+# API Reference
+
+::: agent_space

--- a/docs/concepts/agents.md
+++ b/docs/concepts/agents.md
@@ -1,0 +1,3 @@
+# Agents
+
+Agents coordinate LLM calls.

--- a/docs/concepts/memory.md
+++ b/docs/concepts/memory.md
@@ -1,0 +1,3 @@
+# Memory
+
+Memory stores conversation context.

--- a/docs/concepts/patterns.md
+++ b/docs/concepts/patterns.md
@@ -1,0 +1,3 @@
+# Patterns
+
+Reusable agent patterns.

--- a/docs/concepts/tools.md
+++ b/docs/concepts/tools.md
@@ -1,0 +1,3 @@
+# Tools
+
+Tools enable agents to interact with the world.

--- a/docs/concepts/workflows.md
+++ b/docs/concepts/workflows.md
@@ -1,0 +1,3 @@
+# Workflows
+
+Workflows connect steps.

--- a/docs/cookbooks/add-a-tool.md
+++ b/docs/cookbooks/add-a-tool.md
@@ -1,0 +1,3 @@
+# Add a Tool
+
+Steps to add a tool.

--- a/docs/cookbooks/build-a-router.md
+++ b/docs/cookbooks/build-a-router.md
@@ -1,0 +1,3 @@
+# Build a Router
+
+Example router pattern.

--- a/docs/cookbooks/integrate-new-llm.md
+++ b/docs/cookbooks/integrate-new-llm.md
@@ -1,0 +1,3 @@
+# Integrate a New LLM
+
+Implement provider adapter.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,3 @@
+# Getting Started
+
+Install with `pip install agent-space`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,3 @@
+# Agent Space Docs
+
+Welcome to Agent Space.

--- a/examples/01_quickstart_groupchat.py
+++ b/examples/01_quickstart_groupchat.py
@@ -1,0 +1,5 @@
+from agent_space import agents, providers
+
+llm = providers.get("openai")
+gc = agents.groupchat(llm, agents=["planner", "researcher", "reviewer"])
+print(gc.run("hello").text)

--- a/examples/02_browser_search_drive.py
+++ b/examples/02_browser_search_drive.py
@@ -1,0 +1,4 @@
+from agent_space import tools
+
+b = tools.browser()
+print(b(url="https://example.com").text)

--- a/examples/03_retrievechat_qdrant.py
+++ b/examples/03_retrievechat_qdrant.py
@@ -1,0 +1,7 @@
+from agent_space import agents, memory, providers
+
+llm = providers.get("openai")
+store = memory.VectorStore()
+store.add("1", "hello world doc")
+rc = agents.retrieve_chat(llm, store)
+print(rc.run("hello?").text)

--- a/examples/04_manager_worker_pipeline.py
+++ b/examples/04_manager_worker_pipeline.py
@@ -1,0 +1,5 @@
+from agent_space import agents, providers
+
+llm = providers.get("openai")
+agent = agents.manager_worker(llm, workers=["w1", "w2"])
+print(agent.run("task").text)

--- a/examples/05_realtime_gemini_ws.py
+++ b/examples/05_realtime_gemini_ws.py
@@ -1,0 +1,5 @@
+from agent_space import agents
+
+server = agents.gemini_ws()
+# server.start()  # Uncomment to start server
+print("Server ready", server.host)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,65 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agent-space"
+version = "0.1.0"
+description = "Batteries-included agent toolkit built on AG2"
+authors = [{name = "Agent Space", email = "example@example.com"}]
+license = {text = "MIT"}
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = [
+    "ag2>=0.0.9,<1.0.0",
+    "pydantic>=2.0",
+    "typing-extensions",
+    "typer[all]",
+    "rich",
+]
+
+[project.optional-dependencies]
+rag = ["chromadb", "faiss-cpu", "qdrant-client"]
+browser = ["browser-use", "playwright"]
+google = ["google-api-python-client", "google-auth-oauthlib"]
+realtime = ["fastapi", "uvicorn", "jinja2"]
+otel = ["opentelemetry-sdk"]
+dev = [
+    "pytest",
+    "pytest-asyncio",
+    "pytest-cov",
+    "mypy",
+    "ruff",
+    "black",
+    "mkdocs",
+    "mkdocstrings[python]",
+    "mkdocs-material",
+]
+all = [
+    "agent-space[rag,browser,google,realtime,otel,dev]",
+]
+
+[project.urls]
+Homepage = "https://example.com"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agent_space"]
+
+[tool.mypy]
+python_version = "3.10"
+strict = true
+mypy_path = "src"
+
+[tool.black]
+line-length = 88
+target-version = ["py310"]
+
+[tool.ruff]
+line-length = 88
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM"]
+
+[tool.pytest.ini_options]
+addopts = "-q"
+

--- a/src/agent_space/__init__.py
+++ b/src/agent_space/__init__.py
@@ -1,0 +1,6 @@
+"""Agent Space public API."""
+
+from . import agents as patterns
+from . import providers, tools, workflows
+
+__all__ = ["providers", "tools", "patterns", "workflows"]

--- a/src/agent_space/agents/__init__.py
+++ b/src/agent_space/agents/__init__.py
@@ -1,0 +1,26 @@
+"""Agent patterns."""
+
+from __future__ import annotations
+
+from .autobuild import autobuild
+from .base import Agent, AgentResult
+from .multi.groupchat import groupchat
+from .multi.manager_worker import manager_worker
+from .multi.swarm import swarm
+from .realtime.gemini_ws import gemini_ws
+from .single.plan_act_reflect import plan_act_reflect
+from .single.react import react
+from .single.retrieve_chat import retrieve_chat
+
+__all__ = [
+    "Agent",
+    "AgentResult",
+    "react",
+    "plan_act_reflect",
+    "retrieve_chat",
+    "groupchat",
+    "manager_worker",
+    "swarm",
+    "gemini_ws",
+    "autobuild",
+]

--- a/src/agent_space/agents/autobuild.py
+++ b/src/agent_space/agents/autobuild.py
@@ -1,0 +1,15 @@
+"""AutoBuild facade stub."""
+
+from __future__ import annotations
+
+from ..providers import LLMClient
+from .base import Agent
+
+
+def autobuild(llm: LLMClient) -> Agent:
+    """Return a simple agent; placeholder for AG2 AutoBuild."""
+
+    return Agent(llm)
+
+
+__all__ = ["autobuild"]

--- a/src/agent_space/agents/base.py
+++ b/src/agent_space/agents/base.py
@@ -1,0 +1,41 @@
+"""Agent wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any
+
+from ..providers import LLMChunk, LLMClient
+
+
+@dataclass
+class AgentResult:
+    """Result returned by :meth:`Agent.run`."""
+
+    text: str
+    messages: list[dict[str, str]]
+
+
+class Agent:
+    """Tiny agent wrapper around an :class:`LLMClient`."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        self.llm = llm
+
+    def run(self, input: str | dict[str, str], **kwargs: Any) -> AgentResult:
+        messages = (
+            [input] if isinstance(input, dict) else [{"role": "user", "content": input}]
+        )
+        response = self.llm.generate(messages, **kwargs)
+        messages.append({"role": "assistant", "content": response.text})
+        return AgentResult(text=response.text, messages=messages)
+
+    def run_stream(
+        self, input: str, **kwargs: Any
+    ) -> Iterator[LLMChunk]:  # pragma: no cover - trivial
+        messages = [{"role": "user", "content": input}]
+        yield from self.llm.stream(messages, **kwargs)
+
+
+__all__ = ["Agent", "AgentResult"]

--- a/src/agent_space/agents/multi/groupchat.py
+++ b/src/agent_space/agents/multi/groupchat.py
@@ -1,0 +1,36 @@
+"""Group chat orchestration stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ...providers import LLMClient
+from ..base import Agent, AgentResult
+
+
+class GroupChat(Agent):
+    """Very small group chat that concatenates agent names."""
+
+    def __init__(
+        self,
+        llm: LLMClient,
+        agents: Iterable[str],
+        tools: Iterable[object] | None = None,
+    ) -> None:
+        super().__init__(llm)
+        self.agents = list(agents)
+        self.tools = list(tools or [])
+
+    def run(self, input: str | dict[str, str], **kwargs: object) -> AgentResult:
+        user = input if isinstance(input, str) else input.get("content", "")
+        prefix = ", ".join(self.agents)
+        return super().run(f"{prefix}: {user}", **kwargs)
+
+
+def groupchat(
+    llm: LLMClient, agents: Iterable[str], tools: Iterable[object] | None = None
+) -> GroupChat:
+    return GroupChat(llm, agents, tools)
+
+
+__all__ = ["groupchat", "GroupChat"]

--- a/src/agent_space/agents/multi/manager_worker.py
+++ b/src/agent_space/agents/multi/manager_worker.py
@@ -1,0 +1,28 @@
+"""Manager/worker pattern stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ...providers import LLMClient
+from ..base import Agent, AgentResult
+
+
+class ManagerWorker(Agent):
+    """Simple manager that delegates to worker names."""
+
+    def __init__(self, llm: LLMClient, workers: Iterable[str]) -> None:
+        super().__init__(llm)
+        self.workers = list(workers)
+
+    def run(self, input: str | dict[str, str], **kwargs: object) -> AgentResult:
+        prompt = input if isinstance(input, str) else input.get("content", "")
+        tasks = "; ".join(self.workers)
+        return super().run(f"{tasks}: {prompt}", **kwargs)
+
+
+def manager_worker(llm: LLMClient, workers: Iterable[str]) -> ManagerWorker:
+    return ManagerWorker(llm, workers)
+
+
+__all__ = ["manager_worker", "ManagerWorker"]

--- a/src/agent_space/agents/multi/swarm.py
+++ b/src/agent_space/agents/multi/swarm.py
@@ -1,0 +1,15 @@
+"""Swarm helper stub."""
+
+from __future__ import annotations
+
+from ...providers import LLMClient
+from ..base import Agent
+
+
+def swarm(llm: LLMClient) -> Agent:
+    """Return a basic agent representing a swarm."""
+
+    return Agent(llm)
+
+
+__all__ = ["swarm"]

--- a/src/agent_space/agents/realtime/gemini_ws.py
+++ b/src/agent_space/agents/realtime/gemini_ws.py
@@ -1,0 +1,50 @@
+"""Realtime Gemini WebSocket stub."""
+
+from __future__ import annotations
+
+import threading
+
+import uvicorn
+from fastapi import FastAPI, WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+
+class GeminiRealtimeServer:
+    """Tiny FastAPI server that echoes messages over WebSocket."""
+
+    def __init__(
+        self, model: str = "gemini-pro", host: str = "127.0.0.1", port: int = 8000
+    ) -> None:
+        self.model = model
+        self.host = host
+        self.port = port
+        self.app = FastAPI()
+
+        @self.app.websocket("/ws")
+        async def ws_endpoint(
+            websocket: WebSocket,
+        ) -> None:  # pragma: no cover - network
+            await websocket.accept()
+            try:
+                while True:
+                    data = await websocket.receive_text()
+                    await websocket.send_text(data[::-1])
+            except WebSocketDisconnect:
+                pass
+
+    def start(self) -> None:  # pragma: no cover - network
+        config = uvicorn.Config(
+            self.app, host=self.host, port=self.port, log_level="error"
+        )
+        server = uvicorn.Server(config)
+        thread = threading.Thread(target=server.run, daemon=True)
+        thread.start()
+        self._server = server
+        self._thread = thread
+
+
+def gemini_ws(model: str = "gemini-pro") -> GeminiRealtimeServer:
+    return GeminiRealtimeServer(model=model)
+
+
+__all__ = ["GeminiRealtimeServer", "gemini_ws"]

--- a/src/agent_space/agents/single/plan_act_reflect.py
+++ b/src/agent_space/agents/single/plan_act_reflect.py
@@ -1,0 +1,15 @@
+"""Plan-Act-Reflect pattern stub."""
+
+from __future__ import annotations
+
+from ...providers import LLMClient
+from ..base import Agent
+
+
+def plan_act_reflect(llm: LLMClient) -> Agent:
+    """Return a basic agent implementing plan-act-reflect."""
+
+    return Agent(llm)
+
+
+__all__ = ["plan_act_reflect"]

--- a/src/agent_space/agents/single/react.py
+++ b/src/agent_space/agents/single/react.py
@@ -1,0 +1,15 @@
+"""ReAct pattern stub."""
+
+from __future__ import annotations
+
+from ...providers import LLMClient
+from ..base import Agent
+
+
+def react(llm: LLMClient) -> Agent:
+    """Return a simple :class:`Agent` for the ReAct pattern."""
+
+    return Agent(llm)
+
+
+__all__ = ["react"]

--- a/src/agent_space/agents/single/retrieve_chat.py
+++ b/src/agent_space/agents/single/retrieve_chat.py
@@ -1,0 +1,29 @@
+"""RetrieveChat stub pattern."""
+
+from __future__ import annotations
+
+from ...memory import VectorStore
+from ...providers import LLMClient
+from ..base import Agent, AgentResult
+
+
+class RetrieveChat(Agent):
+    """Very small wrapper that queries a :class:`VectorStore`."""
+
+    def __init__(self, llm: LLMClient, store: VectorStore) -> None:
+        super().__init__(llm)
+        self.store = store
+
+    def run(self, input: str | dict[str, str], **kwargs: object) -> AgentResult:
+        query = input if isinstance(input, str) else input.get("content", "")
+        docs = self.store.query(query)
+        context = docs[0] if docs else "no documents"
+        prompt = f"{context}\nQuestion: {query}"
+        return super().run(prompt, **kwargs)
+
+
+def retrieve_chat(llm: LLMClient, store: VectorStore) -> RetrieveChat:
+    return RetrieveChat(llm, store)
+
+
+__all__ = ["retrieve_chat", "RetrieveChat"]

--- a/src/agent_space/cli.py
+++ b/src/agent_space/cli.py
@@ -1,0 +1,44 @@
+"""Command line interface."""
+
+from __future__ import annotations
+
+import typer
+
+from . import agents, providers, tools
+from .memory import VectorStore
+
+app = typer.Typer(help="Agent Space CLI")
+
+
+@app.command()
+def list(category: str) -> None:
+    """List available components."""
+
+    if category == "tools":
+        typer.echo(", ".join(tools.list_tools()))
+    elif category == "providers":
+        typer.echo("openai, anthropic, gemini")
+    elif category == "agents":
+        typer.echo("groupchat, retrieve_chat")
+    else:
+        raise typer.BadParameter("unknown category")
+
+
+@app.command()
+def run(pattern: str, input: str, provider: str = "openai") -> None:
+    """Run a simple pattern."""
+
+    llm = providers.get(provider)
+    agent: agents.Agent
+    if pattern == "groupchat":
+        agent = agents.groupchat(llm, agents=["a", "b"])
+    elif pattern == "retrievechat":
+        store = VectorStore()
+        store.add("1", "dummy document")
+        agent = agents.retrieve_chat(llm, store)
+    else:
+        raise typer.BadParameter("unknown pattern")
+    typer.echo(agent.run(input).text)
+
+
+__all__ = ["app"]

--- a/src/agent_space/config.py
+++ b/src/agent_space/config.py
@@ -1,0 +1,32 @@
+"""Configuration helpers."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    """Runtime settings loaded from environment variables."""
+
+    openai_api_key: str | None = None
+    anthropic_api_key: str | None = None
+    gemini_api_key: str | None = None
+
+    @classmethod
+    def from_env(cls) -> Settings:
+        return cls(
+            openai_api_key=os.getenv("OPENAI_API_KEY"),
+            anthropic_api_key=os.getenv("ANTHROPIC_API_KEY"),
+            gemini_api_key=os.getenv("GEMINI_API_KEY"),
+        )
+
+
+def get_settings() -> Settings:
+    """Return settings from environment."""
+
+    return Settings.from_env()
+
+
+__all__ = ["Settings", "get_settings"]

--- a/src/agent_space/memory/__init__.py
+++ b/src/agent_space/memory/__init__.py
@@ -1,0 +1,8 @@
+"""Memory utilities."""
+
+from __future__ import annotations
+
+from .conversation import ConversationMemory
+from .vector import VectorStore
+
+__all__ = ["ConversationMemory", "VectorStore"]

--- a/src/agent_space/memory/conversation.py
+++ b/src/agent_space/memory/conversation.py
@@ -1,0 +1,27 @@
+"""Conversation memory."""
+
+from __future__ import annotations
+
+Message = tuple[str, str]
+
+
+class ConversationMemory:
+    """Very small conversation memory with token-window trimming."""
+
+    def __init__(self, max_messages: int = 10) -> None:
+        self.max_messages = max_messages
+        self._messages: list[Message] = []
+
+    def remember(self, role: str, content: str) -> None:
+        self._messages.append((role, content))
+        if len(self._messages) > self.max_messages:
+            self._messages.pop(0)
+
+    def recall(self) -> list[Message]:
+        return list(self._messages)
+
+    def clear(self) -> None:
+        self._messages.clear()
+
+
+__all__ = ["ConversationMemory", "Message"]

--- a/src/agent_space/memory/vector.py
+++ b/src/agent_space/memory/vector.py
@@ -1,0 +1,19 @@
+"""Very small vector store stub."""
+
+from __future__ import annotations
+
+
+class VectorStore:
+    """In-memory vector store used for tests."""
+
+    def __init__(self) -> None:
+        self._store: dict[str, str] = {}
+
+    def add(self, doc_id: str, text: str) -> None:
+        self._store[doc_id] = text
+
+    def query(self, query: str) -> list[str]:  # pragma: no cover - trivial
+        return [text for text in self._store.values() if query.lower() in text.lower()]
+
+
+__all__ = ["VectorStore"]

--- a/src/agent_space/providers/__init__.py
+++ b/src/agent_space/providers/__init__.py
@@ -1,0 +1,8 @@
+"""Provider registry."""
+
+from __future__ import annotations
+
+from .base import LLMChunk, LLMClient, LLMResponse
+from .registry import get
+
+__all__ = ["LLMClient", "LLMChunk", "LLMResponse", "get"]

--- a/src/agent_space/providers/anthropic.py
+++ b/src/agent_space/providers/anthropic.py
@@ -1,0 +1,28 @@
+"""Anthropic provider stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from .base import LLMChunk, LLMResponse
+
+
+class AnthropicClient:
+    """Simple echo client used for tests."""
+
+    def __init__(self, model: str = "claude-3-haiku") -> None:
+        self.model = model
+
+    def generate(self, messages: list[dict[str, str]], **_: Any) -> LLMResponse:
+        text = messages[-1]["content"] if messages else ""
+        length = len(text)
+        return LLMResponse(
+            text=text.upper(), prompt_tokens=length, completion_tokens=length
+        )
+
+    def stream(self, messages: list[dict[str, str]], **_: Any) -> Iterator[LLMChunk]:
+        yield LLMChunk(text=self.generate(messages).text)
+
+
+__all__ = ["AnthropicClient"]

--- a/src/agent_space/providers/base.py
+++ b/src/agent_space/providers/base.py
@@ -1,0 +1,42 @@
+"""Provider base protocols."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+
+@dataclass
+class LLMResponse:
+    """A simple language model response."""
+
+    text: str
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+
+    @property
+    def total_tokens(self) -> int:
+        return self.prompt_tokens + self.completion_tokens
+
+
+@dataclass
+class LLMChunk:
+    """Chunk of streamed LLM output."""
+
+    text: str
+
+
+class LLMClient(Protocol):
+    """Protocol for language model clients."""
+
+    def generate(self, messages: list[dict[str, str]], **kwargs: Any) -> LLMResponse:
+        """Generate a completion from messages."""
+
+    def stream(
+        self, messages: list[dict[str, str]], **kwargs: Any
+    ) -> Iterator[LLMChunk]:
+        """Stream a completion from messages."""
+
+
+__all__ = ["LLMClient", "LLMResponse", "LLMChunk"]

--- a/src/agent_space/providers/gemini.py
+++ b/src/agent_space/providers/gemini.py
@@ -1,0 +1,28 @@
+"""Gemini provider stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from .base import LLMChunk, LLMResponse
+
+
+class GeminiClient:
+    """Simple client that reverses the input text."""
+
+    def __init__(self, model: str = "gemini-pro") -> None:
+        self.model = model
+
+    def generate(self, messages: list[dict[str, str]], **_: Any) -> LLMResponse:
+        text = messages[-1]["content"] if messages else ""
+        length = len(text)
+        return LLMResponse(
+            text=text[::-1], prompt_tokens=length, completion_tokens=length
+        )
+
+    def stream(self, messages: list[dict[str, str]], **_: Any) -> Iterator[LLMChunk]:
+        yield LLMChunk(text=self.generate(messages).text)
+
+
+__all__ = ["GeminiClient"]

--- a/src/agent_space/providers/openai.py
+++ b/src/agent_space/providers/openai.py
@@ -1,0 +1,26 @@
+"""OpenAI provider stub."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from typing import Any
+
+from .base import LLMChunk, LLMResponse
+
+
+class OpenAIClient:
+    """Very small OpenAI-like client used for tests."""
+
+    def __init__(self, model: str = "gpt-4o-mini") -> None:
+        self.model = model
+
+    def generate(self, messages: list[dict[str, str]], **_: Any) -> LLMResponse:
+        text = messages[-1]["content"] if messages else ""
+        length = len(text)
+        return LLMResponse(text=text, prompt_tokens=length, completion_tokens=length)
+
+    def stream(self, messages: list[dict[str, str]], **_: Any) -> Iterator[LLMChunk]:
+        yield LLMChunk(text=self.generate(messages).text)
+
+
+__all__ = ["OpenAIClient"]

--- a/src/agent_space/providers/registry.py
+++ b/src/agent_space/providers/registry.py
@@ -1,0 +1,29 @@
+"""Provider factory registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from .anthropic import AnthropicClient
+from .base import LLMClient
+from .gemini import GeminiClient
+from .openai import OpenAIClient
+
+_FACTORIES: dict[str, Callable[..., LLMClient]] = {
+    "openai": OpenAIClient,
+    "anthropic": AnthropicClient,
+    "gemini": GeminiClient,
+}
+
+
+def get(name: str, **kwargs: object) -> LLMClient:
+    """Return an initialized provider client."""
+
+    try:
+        factory = _FACTORIES[name]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown provider: {name}") from exc
+    return factory(**kwargs)
+
+
+__all__ = ["get"]

--- a/src/agent_space/telemetry/logging.py
+++ b/src/agent_space/telemetry/logging.py
@@ -1,0 +1,18 @@
+"""Logging helpers."""
+
+from __future__ import annotations
+
+import logging
+import uuid
+
+_logger = logging.getLogger("agent_space")
+
+
+def get_logger(run_id: str | None = None) -> logging.Logger:
+    """Return a child logger with ``run_id``."""
+
+    run_id = run_id or str(uuid.uuid4())
+    return _logger.getChild(run_id)
+
+
+__all__ = ["get_logger"]

--- a/src/agent_space/telemetry/tracing.py
+++ b/src/agent_space/telemetry/tracing.py
@@ -1,0 +1,26 @@
+"""Tracing helpers with optional OpenTelemetry."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+try:  # pragma: no cover - optional
+    from opentelemetry import trace
+except Exception:  # pragma: no cover - optional
+    trace = None  # type: ignore[assignment]
+
+
+@contextmanager
+def start_span(name: str) -> Iterator[None]:
+    """Start a tracing span if OpenTelemetry is installed."""
+
+    if trace is None:
+        yield
+    else:  # pragma: no cover - optional
+        tracer = trace.get_tracer("agent_space")
+        with tracer.start_as_current_span(name):
+            yield
+
+
+__all__ = ["start_span"]

--- a/src/agent_space/tools/__init__.py
+++ b/src/agent_space/tools/__init__.py
@@ -1,0 +1,18 @@
+"""Tools public API."""
+
+from __future__ import annotations
+
+from .browser import browser
+from .google_drive import google_drive
+from .google_search import google_search
+from .registry import get, list_tools
+from .youtube_search import youtube_search
+
+__all__ = [
+    "get",
+    "list_tools",
+    "browser",
+    "google_search",
+    "google_drive",
+    "youtube_search",
+]

--- a/src/agent_space/tools/base.py
+++ b/src/agent_space/tools/base.py
@@ -1,0 +1,26 @@
+"""Tool base abstractions."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from pydantic import BaseModel
+
+
+class ToolResult(BaseModel):
+    """Simple tool result."""
+
+    text: str
+
+
+class Tool(Protocol):
+    """Protocol for tools."""
+
+    name: str
+    description: str
+    Args: type[BaseModel]
+
+    def __call__(self, **kwargs: Any) -> ToolResult: ...
+
+
+__all__ = ["Tool", "ToolResult"]

--- a/src/agent_space/tools/browser.py
+++ b/src/agent_space/tools/browser.py
@@ -1,0 +1,33 @@
+"""Browser tool stub."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from .base import Tool, ToolResult
+from .registry import register
+
+
+class BrowserArgs(BaseModel):
+    url: str
+
+
+class Browser:
+    name = "browser"
+    description = "Fetch a URL"
+    Args: type[BaseModel] = BrowserArgs
+
+    def __call__(self, **kwargs: Any) -> ToolResult:  # pragma: no cover - simple
+        args = BrowserArgs(**kwargs)
+        return ToolResult(text=f"fetched {args.url}")
+
+
+def browser() -> Tool:
+    return Browser()
+
+
+register("browser", browser)
+
+__all__ = ["browser", "Browser", "BrowserArgs"]

--- a/src/agent_space/tools/google_drive.py
+++ b/src/agent_space/tools/google_drive.py
@@ -1,0 +1,33 @@
+"""Google Drive stub tool."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from .base import Tool, ToolResult
+from .registry import register
+
+
+class GoogleDriveArgs(BaseModel):
+    file_id: str
+
+
+class GoogleDrive:
+    name = "google_drive"
+    description = "Read file from drive"
+    Args: type[BaseModel] = GoogleDriveArgs
+
+    def __call__(self, **kwargs: Any) -> ToolResult:  # pragma: no cover - simple
+        args = GoogleDriveArgs(**kwargs)
+        return ToolResult(text=f"contents of {args.file_id}")
+
+
+def google_drive() -> Tool:
+    return GoogleDrive()
+
+
+register("google_drive", google_drive)
+
+__all__ = ["google_drive", "GoogleDrive", "GoogleDriveArgs"]

--- a/src/agent_space/tools/google_search.py
+++ b/src/agent_space/tools/google_search.py
@@ -1,0 +1,33 @@
+"""Google search stub."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from .base import Tool, ToolResult
+from .registry import register
+
+
+class GoogleSearchArgs(BaseModel):
+    query: str
+
+
+class GoogleSearch:
+    name = "google_search"
+    description = "Return top search result"
+    Args: type[BaseModel] = GoogleSearchArgs
+
+    def __call__(self, **kwargs: Any) -> ToolResult:  # pragma: no cover - simple
+        args = GoogleSearchArgs(**kwargs)
+        return ToolResult(text=f"search results for {args.query}")
+
+
+def google_search() -> Tool:
+    return GoogleSearch()
+
+
+register("google_search", google_search)
+
+__all__ = ["google_search", "GoogleSearch", "GoogleSearchArgs"]

--- a/src/agent_space/tools/registry.py
+++ b/src/agent_space/tools/registry.py
@@ -1,0 +1,37 @@
+"""Tool registry."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from .base import Tool
+
+T = TypeVar("T", bound=Tool)
+
+_REGISTRY: dict[str, Callable[[], Tool]] = {}
+
+
+def register(name: str, factory: Callable[[], T]) -> None:
+    """Register a tool factory under ``name``."""
+
+    _REGISTRY[name] = factory
+
+
+def get(name: str) -> Tool:
+    """Retrieve a tool instance."""
+
+    try:
+        factory = _REGISTRY[name]
+    except KeyError as exc:  # pragma: no cover - defensive
+        raise ValueError(f"Unknown tool: {name}") from exc
+    return factory()
+
+
+def list_tools() -> list[str]:
+    """Return the names of available tools."""
+
+    return sorted(_REGISTRY)
+
+
+__all__ = ["register", "get", "list_tools"]

--- a/src/agent_space/tools/youtube_search.py
+++ b/src/agent_space/tools/youtube_search.py
@@ -1,0 +1,33 @@
+"""YouTube search stub."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+from .base import Tool, ToolResult
+from .registry import register
+
+
+class YouTubeSearchArgs(BaseModel):
+    query: str
+
+
+class YouTubeSearch:
+    name = "youtube_search"
+    description = "Search YouTube videos"
+    Args: type[BaseModel] = YouTubeSearchArgs
+
+    def __call__(self, **kwargs: Any) -> ToolResult:  # pragma: no cover - simple
+        args = YouTubeSearchArgs(**kwargs)
+        return ToolResult(text=f"videos for {args.query}")
+
+
+def youtube_search() -> Tool:
+    return YouTubeSearch()
+
+
+register("youtube_search", youtube_search)
+
+__all__ = ["youtube_search", "YouTubeSearch", "YouTubeSearchArgs"]

--- a/src/agent_space/utils/json_io.py
+++ b/src/agent_space/utils/json_io.py
@@ -1,0 +1,24 @@
+"""JSON I/O utilities."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def read_json(path: str | Path) -> Any:
+    """Read JSON from ``path``."""
+
+    with Path(path).open("r", encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def write_json(path: str | Path, data: Any) -> None:
+    """Write ``data`` as JSON to ``path``."""
+
+    with Path(path).open("w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+
+__all__ = ["read_json", "write_json"]

--- a/src/agent_space/utils/prompts.py
+++ b/src/agent_space/utils/prompts.py
@@ -1,0 +1,12 @@
+"""Prompt helpers."""
+
+from __future__ import annotations
+
+
+def format_prompt(template: str, **kwargs: object) -> str:
+    """Format ``template`` with ``kwargs``."""
+
+    return template.format(**kwargs)
+
+
+__all__ = ["format_prompt"]

--- a/src/agent_space/utils/retry.py
+++ b/src/agent_space/utils/retry.py
@@ -1,0 +1,25 @@
+"""Retry utilities."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+
+def retry(fn: Callable[[], T], attempts: int = 3, delay: float = 0.01) -> T:
+    """Execute ``fn`` with simple retries."""
+
+    for i in range(attempts):
+        try:
+            return fn()
+        except Exception:
+            if i == attempts - 1:
+                raise
+            time.sleep(delay)
+    raise RuntimeError("unreachable")
+
+
+__all__ = ["retry"]

--- a/src/agent_space/workflows/__init__.py
+++ b/src/agent_space/workflows/__init__.py
@@ -1,0 +1,9 @@
+"""Workflow utilities."""
+
+from __future__ import annotations
+
+from .dag import DAG, Step
+from .presets.rag_minimal import rag_minimal
+from .presets.research_pipeline import research_pipeline
+
+__all__ = ["DAG", "Step", "rag_minimal", "research_pipeline"]

--- a/src/agent_space/workflows/dag.py
+++ b/src/agent_space/workflows/dag.py
@@ -1,0 +1,34 @@
+"""Lightweight workflow DAG."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass
+class Step:
+    """Workflow step."""
+
+    name: str
+    func: Callable[[Any], Any]
+
+    def run(self, data: Any) -> Any:
+        return self.func(data)
+
+
+class DAG:
+    """A minimal directed acyclic workflow."""
+
+    def __init__(self, steps: list[Step]) -> None:
+        self.steps = steps
+
+    def run(self, initial: Any = None) -> Iterator[dict[str, Any]]:
+        data = initial
+        for step in self.steps:
+            data = step.run(data)
+            yield {"step": step.name, "output": data}
+
+
+__all__ = ["Step", "DAG"]

--- a/src/agent_space/workflows/presets/rag_minimal.py
+++ b/src/agent_space/workflows/presets/rag_minimal.py
@@ -1,0 +1,16 @@
+"""RAG minimal workflow stub."""
+
+from __future__ import annotations
+
+from ..dag import DAG, Step
+
+
+def rag_minimal() -> DAG:
+    steps = [
+        Step("retrieve", lambda _: "docs"),
+        Step("answer", lambda docs: f"answer from {docs}"),
+    ]
+    return DAG(steps)
+
+
+__all__ = ["rag_minimal"]

--- a/src/agent_space/workflows/presets/research_pipeline.py
+++ b/src/agent_space/workflows/presets/research_pipeline.py
@@ -1,0 +1,17 @@
+"""Research pipeline workflow stub."""
+
+from __future__ import annotations
+
+from ..dag import DAG, Step
+
+
+def research_pipeline() -> DAG:
+    steps = [
+        Step("search", lambda _: "results"),
+        Step("read", lambda results: f"read {results}"),
+        Step("draft", lambda text: f"draft from {text}"),
+    ]
+    return DAG(steps)
+
+
+__all__ = ["research_pipeline"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,12 @@
+"""Test fixtures."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_space import providers
+
+
+@pytest.fixture
+def llm() -> providers.LLMClient:
+    return providers.get("openai")

--- a/tests/test_agents_multi.py
+++ b/tests/test_agents_multi.py
@@ -1,0 +1,7 @@
+from agent_space import agents
+
+
+def test_groupchat(llm) -> None:
+    gc = agents.groupchat(llm, agents=["planner", "researcher", "reviewer"])
+    out = gc.run("hi").text
+    assert "planner" in out and "reviewer" in out

--- a/tests/test_agents_single.py
+++ b/tests/test_agents_single.py
@@ -1,0 +1,6 @@
+from agent_space import agents
+
+
+def test_react(llm) -> None:
+    agent = agents.react(llm)
+    assert agent.run("hello").text == "hello"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,17 @@
+from typer.testing import CliRunner
+
+from agent_space.cli import app
+
+runner = CliRunner()
+
+
+def test_cli_list() -> None:
+    result = runner.invoke(app, ["list", "tools"])
+    assert result.exit_code == 0
+    assert "browser" in result.stdout
+
+
+def test_cli_run() -> None:
+    result = runner.invoke(app, ["run", "groupchat", "hello"])
+    assert result.exit_code == 0
+    assert "hello" in result.stdout

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -1,0 +1,12 @@
+from agent_space import providers
+
+
+def test_provider_generate(llm: providers.LLMClient) -> None:
+    resp = llm.generate([{"role": "user", "content": "hi"}])
+    assert resp.text == "hi"
+    assert resp.total_tokens == resp.prompt_tokens + resp.completion_tokens
+
+
+def test_registry_get() -> None:
+    client = providers.get("anthropic")
+    assert client.generate([{"role": "user", "content": "hi"}]).text == "HI"

--- a/tests/test_realtime.py
+++ b/tests/test_realtime.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+
+from agent_space import agents
+
+
+def test_realtime_ws() -> None:
+    server = agents.gemini_ws()
+    client = TestClient(server.app)
+    with client.websocket_connect("/ws") as ws:
+        ws.send_text("abc")
+        assert ws.receive_text() == "cba"

--- a/tests/test_retrieve_chat.py
+++ b/tests/test_retrieve_chat.py
@@ -1,0 +1,9 @@
+from agent_space import agents, memory
+
+
+def test_retrieve_chat(llm) -> None:
+    store = memory.VectorStore()
+    store.add("1", "onboarding sop")
+    rc = agents.retrieve_chat(llm, store)
+    out = rc.run("onboarding").text
+    assert "onboarding" in out.lower()

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,8 @@
+from agent_space import tools
+
+
+def test_tools_registry() -> None:
+    names = tools.list_tools()
+    assert "browser" in names
+    tool = tools.get("browser")
+    assert tool(url="https://example.com").text.startswith("fetched")


### PR DESCRIPTION
## Summary
- add typed provider protocol and registry for OpenAI, Anthropic, Gemini stubs
- implement tool registry and example browser/search/drive/YouTube tools
- wire lightweight agent patterns, memory, workflows, telemetry, CLI and tests

## Testing
- `ruff check src tests examples`
- `black src tests examples`
- `mypy src`
- `PYTHONPATH=src pytest -q`
- `mkdocs build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae9bf4cf4083339d586eb4244f9b3f