### PR TITLE
Add interactive text UI for building agents

### DIFF
--- a/src/agent_space/__init__.py
+++ b/src/agent_space/__init__.py
@@ -1,6 +1,6 @@
 """Agent Space public API."""
 
 from . import agents as patterns
-from . import providers, tools, workflows
+from . import providers, tools, ui, workflows
 
-__all__ = ["providers", "tools", "patterns", "workflows"]
+__all__ = ["providers", "tools", "patterns", "workflows", "ui"]

--- a/src/agent_space/cli.py
+++ b/src/agent_space/cli.py
@@ -6,6 +6,7 @@ import typer
 
 from . import agents, providers, tools
 from .memory import VectorStore
+from .ui import interactive
 
 app = typer.Typer(help="Agent Space CLI")
 
@@ -39,6 +40,13 @@ def run(pattern: str, input: str, provider: str = "openai") -> None:
     else:
         raise typer.BadParameter("unknown pattern")
     typer.echo(agent.run(input).text)
+
+
+@app.command()
+def ui() -> None:
+    """Launch a simple interactive UI for building and running agents."""
+
+    interactive()
 
 
 __all__ = ["app"]

--- a/src/agent_space/ui.py
+++ b/src/agent_space/ui.py
@@ -1,0 +1,52 @@
+"""Simple text UI for building agents and running them."""
+
+from __future__ import annotations
+
+from rich.console import Console
+from rich.prompt import Prompt
+
+from . import agents, providers
+from .memory import VectorStore
+
+console = Console()
+
+
+def build_agent() -> agents.Agent:
+    """Interactively construct an agent pattern."""
+
+    pattern = Prompt.ask("Select pattern", choices=["groupchat", "retrieve_chat"])
+    provider = Prompt.ask(
+        "LLM provider", choices=["openai", "anthropic", "gemini"], default="openai"
+    )
+    llm = providers.get(provider)
+    if pattern == "groupchat":
+        names = Prompt.ask("Agent names (comma-separated)", default="a,b")
+        agent_names = [name.strip() for name in names.split(",") if name.strip()]
+        return agents.groupchat(llm, agents=agent_names)
+    else:
+        store = VectorStore()
+        console.print("Enter documents for retrieval (blank line to finish):")
+        idx = 1
+        while True:
+            doc = Prompt.ask(f"doc #{idx}", default="")
+            if not doc:
+                break
+            store.add(str(idx), doc)
+            idx += 1
+        return agents.retrieve_chat(llm, store)
+
+
+def interactive() -> None:
+    """Interactive loop for the agent built by :func:`build_agent`."""
+
+    agent = build_agent()
+    console.print("[bold]Agent ready. Submit blank input to exit.[/bold]")
+    while True:
+        question = Prompt.ask("You", default="")
+        if not question:
+            break
+        result = agent.run(question)
+        console.print(f"[green]{result.text}[/green]")
+
+
+__all__ = ["interactive", "build_agent"]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,23 @@
+"""Tests for the interactive UI helpers."""
+
+from __future__ import annotations
+
+from agent_space.ui import build_agent
+
+
+def test_build_agent_groupchat(monkeypatch) -> None:
+    responses = iter(["groupchat", "openai", "alice,bob"])
+    monkeypatch.setattr(
+        "agent_space.ui.Prompt.ask", lambda *args, **kwargs: next(responses)
+    )
+    agent = build_agent()
+    assert agent.agents == ["alice", "bob"]
+
+
+def test_build_agent_retrieve_chat(monkeypatch) -> None:
+    responses = iter(["retrieve_chat", "openai", "doc one", ""])
+    monkeypatch.setattr(
+        "agent_space.ui.Prompt.ask", lambda *args, **kwargs: next(responses)
+    )
+    agent = build_agent()
+    assert agent.store._store == {"1": "doc one"}


### PR DESCRIPTION
## Summary
- add `ui` module providing an interactive text interface
- expose a new `agent-space ui` command to build and run agent patterns
- export `ui` module from public API
- add tests for `build_agent`

## Testing
- `pytest -q`
- `ruff check src tests`


------
https://chatgpt.com/codex/tasks/task_e_68aea12b78f48333ba3e837b87f6d1c5